### PR TITLE
SDK-5741: Migrate browserstack-sdk install from PyPI to S3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
 browserstack-local
-selenium>=3.14
+jsonmerge
+selenium==4.*
+psutil
 pytest==7.4.4
+pytest-variables
 pytest-selenium
-browserstack-sdk
+browserstack-sdk @ https://sdk-assets.browserstack.com/python/browserstack_sdk-latest.tar.gz
+pytest-html==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,5 @@
 browserstack-local
-jsonmerge
-selenium==4.*
-psutil
+selenium>=3.14
 pytest==7.4.4
-pytest-variables
 pytest-selenium
 browserstack-sdk @ https://sdk-assets.browserstack.com/python/browserstack_sdk-latest.tar.gz
-pytest-html==3.2.0


### PR DESCRIPTION
## Summary
- Update `requirements.txt` to install `browserstack-sdk` from BrowserStack-hosted S3 instead of PyPI
- PyPI flagged the package for obfuscated code; the package is now hosted at `sdk-assets.browserstack.com`
- Install URL: `https://sdk-assets.browserstack.com/python/browserstack_sdk-latest.tar.gz`

## Test plan
- [ ] Run `pip install -r requirements.txt` in a clean venv — SDK installs from S3
- [ ] Run tests with `browserstack-sdk` CLI — tests pass, observability build generates

🤖 Generated with [Claude Code](https://claude.com/claude-code)